### PR TITLE
fixed typo

### DIFF
--- a/cicd/azure-devops/README.md
+++ b/cicd/azure-devops/README.md
@@ -67,7 +67,7 @@ For Image scan:
 ```./twistcli images scan  --address $(PCC_CONSOLE_URL) -u $(PCC_USER) -p $(PCC_PASS) --details $(image_name):$(tag)```
 
 For serverless scan:
-```\twistcli.exe serverless scan --address $(PCC_CONSOLE_URL) -u $(PCC_USER) -p $(PCC_PASS) --details $(FUNCTION_ZIP_NAME)```
+```./twistcli.exe serverless scan --address $(PCC_CONSOLE_URL) -u $(PCC_USER) -p $(PCC_PASS) --details $(FUNCTION_ZIP_NAME)```
 
 Example screenshot for serverless scan:
   


### PR DESCRIPTION
fixed line 70. 

it was \twistcli.exe serverless scan and I changed it to ./twistcli.exe

## Description

<!--- Describe your changes in detail -->
Fixed line 70. Caught a type
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fixed typo
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
